### PR TITLE
fix: add automated GitHub Release creation workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,63 @@
+# Auto-create GitHub Release
+#
+# This workflow automatically creates a GitHub Release after a version bump PR is merged.
+# It detects version bump commits and creates a release with the corresponding tag.
+#
+# When it runs:
+# - Automatically: When a PR is merged to main that contains a version bump commit
+#
+# What it does:
+# 1. Detects if the merged commit is a version bump (starts with "chore: bump version")
+# 2. Extracts the version number from the commit message
+# 3. Creates a git tag for the version
+# 4. Creates a GitHub Release with the tag and CHANGELOG excerpt
+
+name: Create Release
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Check if this is a version bump commit
+      id: check_version_bump
+      run: |
+        COMMIT_MSG=$(git log -1 --pretty=format:"%s")
+        echo "Commit message: $COMMIT_MSG"
+
+        if echo "$COMMIT_MSG" | grep -qE "^chore: bump version to"; then
+          echo "is_version_bump=true" >> $GITHUB_OUTPUT
+          VERSION=$(echo "$COMMIT_MSG" | sed -n 's/^chore: bump version to \([0-9.]*\).*/\1/p')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "This is a version bump to $VERSION"
+        else
+          echo "is_version_bump=false" >> $GITHUB_OUTPUT
+          echo "Not a version bump commit"
+        fi
+
+    - name: Create GitHub Release
+      if: steps.check_version_bump.outputs.is_version_bump == 'true'
+      run: |
+        VERSION="${{ steps.check_version_bump.outputs.version }}"
+
+        # Extract release notes from CHANGELOG.md for this version
+        RELEASE_NOTES=$(sed -n "/^## \[$VERSION\]/,/^## \[/p" CHANGELOG.md | sed '$d' | tail -n +2)
+
+        # Create release
+        gh release create "v$VERSION" \
+          --title "Release v$VERSION" \
+          --notes "$RELEASE_NOTES"
+
+        echo "Created release v$VERSION"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,29 +149,32 @@ jobs:
       if: steps.bump_type.outputs.bump_type != 'none'
       run: |
         BRANCH_NAME="release/v${{ steps.version.outputs.new_version }}"
-        
+
         # Create and checkout new branch
         git checkout -b "$BRANCH_NAME"
-        
+
         # Commit changes
         git add src/strava_fetcher/__init__.py CHANGELOG.md
         git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }} [skip ci]"
-        
+
         # Push branch
         git push origin "$BRANCH_NAME"
-        
+
+        # Create PR body
+        PR_BODY="Automated version bump to ${{ steps.version.outputs.new_version }}
+
+        This PR was automatically created by the release workflow.
+
+        **Changes:**
+        - Updated version in src/strava_fetcher/__init__.py
+        - Updated CHANGELOG.md with release notes
+
+        **Note:** After merging this PR, the GitHub Release will be automatically created by the create-release workflow."
+
         # Create PR using gh CLI
         gh pr create \
           --title "chore: bump version to ${{ steps.version.outputs.new_version }}" \
-          --body "Automated version bump to ${{ steps.version.outputs.new_version }}
-
-This PR was automatically created by the release workflow.
-
-**Changes:**
-- Updated version in \`src/strava_fetcher/__init__.py\`
-- Updated CHANGELOG.md with release notes
-
-**Note:** After merging this PR, manually create the GitHub Release with tag \`v${{ steps.version.outputs.new_version }}\`." \
+          --body "$PR_BODY" \
           --base main \
           --head "$BRANCH_NAME"
       env:


### PR DESCRIPTION
- Create separate create-release.yml workflow
- Automatically creates release after version bump PR is merged
- No manual steps required for complete automation
- Fix YAML syntax in release.yml PR body