### PR TITLE
fix: use PAT_TOKEN for creating PRs in release workflow

### DIFF
--- a/.github/SETUP.md
+++ b/.github/SETUP.md
@@ -1,0 +1,62 @@
+# GitHub Actions Setup
+
+## Required Secrets
+
+To enable the automated release workflow, you need to create a Personal Access Token (PAT) and add it as a repository secret.
+
+### Creating a Personal Access Token (PAT)
+
+1. Go to **GitHub Settings** → **Developer settings** → **Personal access tokens** → **Tokens (classic)**
+   - Direct link: https://github.com/settings/tokens/new
+
+2. Click **Generate new token** → **Generate new token (classic)**
+
+3. Configure the token:
+   - **Note**: `StravaFetcher Release Automation`
+   - **Expiration**: Choose your preferred expiration (recommend 90 days or 1 year)
+   - **Scopes**: Select the following:
+     - ✅ `repo` (Full control of private repositories)
+       - This includes `repo:status`, `repo_deployment`, `public_repo`, etc.
+     - ✅ `workflow` (Update GitHub Action workflows)
+
+4. Click **Generate token** at the bottom
+
+5. **IMPORTANT**: Copy the token immediately - you won't be able to see it again!
+
+### Adding the Secret to Your Repository
+
+1. Go to your repository: https://github.com/hope0hermes/StravaFetcher
+
+2. Navigate to **Settings** → **Secrets and variables** → **Actions**
+   - Direct link: https://github.com/hope0hermes/StravaFetcher/settings/secrets/actions
+
+3. Click **New repository secret**
+
+4. Configure the secret:
+   - **Name**: `PAT_TOKEN`
+   - **Value**: Paste the Personal Access Token you created
+   - Click **Add secret**
+
+### Verification
+
+After adding the secret:
+1. The release workflow will be able to create PRs automatically
+2. Merge any PR with `feat!:`, `feat:`, or `fix:` commits to test the automation
+3. The workflow should create a version bump PR
+4. After merging the version bump PR, a GitHub Release will be created automatically
+
+### Security Notes
+
+- The PAT has access to all your repositories, so keep it secure
+- Consider creating a dedicated GitHub account (bot account) for automation if working in a team
+- Set an expiration date and create a calendar reminder to renew it
+- Never commit the token to the repository
+- You can revoke the token at any time from https://github.com/settings/tokens
+
+### Troubleshooting
+
+If the workflow fails with "GitHub Actions is not permitted to create or approve pull requests":
+- Verify the `PAT_TOKEN` secret exists and is correctly named
+- Verify the PAT has the `repo` and `workflow` scopes
+- Check if the PAT has expired
+- Ensure you're using a classic PAT, not a fine-grained token (fine-grained tokens may have issues with some operations)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@
 # This workflow automatically manages versioning and releases based on commit messages.
 # It uses Conventional Commits to determine the version bump type.
 #
+# REQUIRED SECRET:
+# - PAT_TOKEN: Personal Access Token with 'repo' and 'pull_requests' scopes
+#   Create at: https://github.com/settings/tokens/new
+#   Add to repo secrets at: https://github.com/hope0hermes/StravaFetcher/settings/secrets/actions
+#
 # When it runs:
 # - Automatically: When a PR is merged to main (via "push: branches: [main]")
 # - Manually: Via GitHub Actions UI (workflow_dispatch button)
@@ -12,9 +17,8 @@
 # 2. Determines version bump type (major/minor/patch/none)
 # 3. Updates version in src/strava_fetcher/__init__.py using hatch
 # 4. Updates CHANGELOG.md with new version and commit list
-# 5. Commits version bump back to main with [skip ci] to avoid recursion
-# 6. Creates git tag (e.g., v1.1.0)
-# 7. Creates GitHub Release with tag
+# 5. Creates a PR with version bump changes
+# 6. After PR is merged, create-release.yml automatically creates the GitHub Release
 #
 # Conventional Commit Format → Version Bump:
 # - "feat:" or "feature:" → MINOR bump (1.0.0 → 1.1.0) - New features
@@ -26,12 +30,6 @@
 # - Version stored in: src/strava_fetcher/__init__.py (__version__ = "1.0.0")
 # - Hatch reads/writes version automatically (configured in pyproject.toml)
 # - Single source of truth prevents version conflicts
-#
-# Important Notes:
-# - Use [skip ci] in commit message to prevent infinite workflow loops
-# - Requires "contents: write" permission to push commits and create releases
-# - fetch-depth: 0 ensures we have full git history to find previous tags
-# - If no previous tag exists, analyzes all commits in repository
 
 name: Release
 
@@ -51,7 +49,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Fetch all history so we can find previous tags
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.PAT_TOKEN }}
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -178,4 +176,4 @@ jobs:
           --base main \
           --head "$BRANCH_NAME"
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
- GITHUB_TOKEN cannot create PRs from workflows (GitHub security)
- Update workflow to use PAT_TOKEN secret instead
- Add comprehensive setup documentation in .github/SETUP.md
- Document PAT creation and configuration steps