### PR TITLE
fix: use PAT_TOKEN with fallback in checkout step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Fetch all history so we can find previous tags
-        token: ${{ secrets.PAT_TOKEN }}
+        token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
- Add fallback to GITHUB_TOKEN in checkout to prevent empty token error
- Simplify workflow by removing PAT check (secret exists)
- Keep using PAT_TOKEN for gh CLI to create PRs