### PR TITLE
fix: trigger checks on version bump PRs

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -22,6 +22,9 @@
 name: Lint Commit Messages
 
 on:
+  push:
+    branches:
+      - 'release/**'  # Trigger on version bump branches
   pull_request:
     branches: [ main ]
     types: [ opened, synchronize, reopened, edited ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@
 # Trigger Strategy:
 # - "push: branches: [main]" - Runs after PR merges to main (verification)
 # - "pull_request: branches: [main]" - Runs on PRs targeting main (pre-merge check)
+# - "push: branches: [release/**]" - Runs on version bump PRs created by Release workflow
 #
 # Why NOT "branches: ['**']" for push?
 # - Would cause duplicate runs: once for push to feature branch, once for PR
@@ -15,12 +16,15 @@
 # 1. You push to feature branch with open PR → Runs ONCE (via pull_request trigger)
 # 2. You push to feature branch without PR → Does NOT run (no waste)
 # 3. PR gets merged to main → Runs ONCE (via push to main trigger)
+# 4. Release workflow creates version bump PR → Runs ONCE (via push to release/** trigger)
 
 name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release/**'  # Trigger on version bump branches
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
- Add push trigger for release/** branches to tests workflow
- Add push trigger for release/** branches to commitlint workflow
- Allows checks to run on PRs created by Release workflow
- Fixes issue where version bump PRs had no checks