### PR TITLE
fix: trigger checks after creating version bump PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,5 +191,10 @@ jobs:
           --body "$PR_BODY" \
           --base main \
           --head "$BRANCH_NAME"
+        
+        # Trigger checks on the PR by creating an empty commit
+        # This ensures checks run and appear as required status checks
+        git commit --allow-empty -m "chore: trigger CI checks"
+        git push origin "$BRANCH_NAME"
       env:
         GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
- Add empty commit after PR creation to trigger workflows
- Ensures checks run and appear as required status checks on PR
- Push-triggered workflows now associated with the PR