### PR TITLE
fix: use gh release create with --target to auto-create tags

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,6 +28,12 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Configure Git
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
 
     - name: Check if this is a version bump commit
       id: check_version_bump
@@ -60,18 +66,12 @@ jobs:
           exit 0
         fi
 
-        # Create tag if it doesn't exist
-        if ! git tag | grep -q "^v$VERSION$"; then
-          git tag "v$VERSION"
-          git push origin "v$VERSION"
-          echo "Created and pushed tag v$VERSION"
-        fi
-
-        # Create release
+        # Create release (this will also create the tag if it doesn't exist)
         gh release create "v$VERSION" \
+          --target main \
           --title "Release v$VERSION" \
           --notes "$RELEASE_NOTES"
 
-        echo "Created release v$VERSION"
+        echo "Created release v$VERSION with tag"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Add git config for github-actions bot user
- Use --target main flag in gh release create
- This automatically creates the tag when creating the release
- Removes manual git tag/push which fails with GITHUB_TOKEN permissions