### PR TITLE
feat: add version and package info helper functions

### DIFF
--- a/src/strava_fetcher/__init__.py
+++ b/src/strava_fetcher/__init__.py
@@ -2,6 +2,21 @@
 
 __version__ = "1.4.1"
 
+
+def get_version() -> str:
+    """Get the current version of strava_fetcher."""
+    return __version__
+
+
+def get_package_info() -> dict[str, str]:
+    """Get package information including name and version."""
+    return {
+        "name": "strava-fetcher",
+        "version": __version__,
+        "description": "A robust pipeline for syncing Strava activity data and streams locally",
+    }
+
+
 from .cli import main
 from .exceptions import (
     APIError,
@@ -14,6 +29,8 @@ from .pipeline import StravaSyncPipeline
 from .settings import Settings
 
 __all__ = [
+    "get_version",
+    "get_package_info",
     "main",
     "StravaFetcherError",
     "APIError",

--- a/src/strava_fetcher/__init__.py
+++ b/src/strava_fetcher/__init__.py
@@ -2,6 +2,17 @@
 
 __version__ = "1.4.1"
 
+from .cli import main
+from .exceptions import (
+    APIError,
+    ConfigError,
+    RateLimitError,
+    StravaFetcherError,
+    UnauthorizedError,
+)
+from .pipeline import StravaSyncPipeline
+from .settings import Settings
+
 
 def get_version() -> str:
     """Get the current version of strava_fetcher."""
@@ -15,18 +26,6 @@ def get_package_info() -> dict[str, str]:
         "version": __version__,
         "description": "A robust pipeline for syncing Strava activity data and streams locally",
     }
-
-
-from .cli import main
-from .exceptions import (
-    APIError,
-    ConfigError,
-    RateLimitError,
-    StravaFetcherError,
-    UnauthorizedError,
-)
-from .pipeline import StravaSyncPipeline
-from .settings import Settings
 
 __all__ = [
     "get_version",

--- a/src/strava_fetcher/__init__.py
+++ b/src/strava_fetcher/__init__.py
@@ -24,7 +24,7 @@ def get_package_info() -> dict[str, str]:
     return {
         "name": "strava-fetcher",
         "version": __version__,
-        "description": "A robust pipeline for syncing Strava activity data and streams locally",
+        "description": "A robust pipeline for syncing Strava activity data",
     }
 
 __all__ = [


### PR DESCRIPTION
Add public API functions for retrieving version and package metadata.

**Features**:
- `get_version()`: returns current version string
- `get_package_info()`: returns dict with name, version, and description

Makes it easier for downstream consumers to programmatically access package information.

This will trigger v1.4.2 release and test the full e2e workflow:
1. Merge → Release workflow creates version bump PR  
2. Merge version bump → Create-release workflow makes GitHub Release
3. Release published → Publish workflow publishes to Devpi