### PR TITLE
chore: sync workflows and make publish manual-only

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -22,3 +22,5 @@ on:
 jobs:
   create-release:
     uses: hope0hermes/SharedWorkflows/.github/workflows/reusable-create-release.yml@main
+    secrets:
+      github-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,6 @@
 name: Publish to Devpi
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
**Changes:**
- Add PAT_TOKEN to create-release.yml (enables workflow chaining but we're making publish manual)
- Remove auto-trigger from publish.yml (keep manual workflow_dispatch only)

**Rationale:**
Based on debugging experience, publishing should be a manual step for better control and safety. Keeping automatic release creation, but requiring manual trigger for publishing to Devpi.